### PR TITLE
Fix doc.get

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@
           return databases[db].remove(object, options);
         },
         get: function(db, object, options) {
-          return databases[db].get(db, object, options);
+          return databases[db].get(object, options);
         },
         session: {},
         errors: {},


### PR DESCRIPTION
Fixes issue when trying to fetch a single doc. Original typo? Current implementation is patting the db name into the docid field of the pouchdb function.