### PR TITLE
Make $pouch api work with no options passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,16 +134,16 @@
           })
         },
         put: function(db, object, options) {
-          return databases[db].put(object, options);
+          return databases[db].put(object, options || {});
         },
         post: function(db, object, options) {
-          return databases[db].post(object, options);
+          return databases[db].post(object, options || {});
         },
         remove: function(db, object, options) {
-          return databases[db].remove(object, options);
+          return databases[db].remove(object, options || {});
         },
         get: function(db, object, options) {
-          return databases[db].get(object, options);
+          return databases[db].get(object, options || {});
         },
         session: {},
         errors: {},


### PR DESCRIPTION
Currently, vue-pouch expects options argument to be provided and passes it to PouchDB. If no options were provided (not even an empty object), PouchDB receives explicit `undefined` and attempts to read options from it, resulting in error.

I believe vue-pouch should mimic PouchDB approach here and allow a call without options. I propose a change that may not be ideally clean - we're passing empty object even if caller doesn't - but retains simple syntax.