### PR TITLE
:beetle: PouchDB - Cannot read property 'force' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,16 +134,16 @@
           })
         },
         put: function(db, object, options) {
-          return databases[db].put(object, options);
+          return databases[db].put(object, options || {});
         },
         post: function(db, object, options) {
-          return databases[db].post(object, options);
+          return databases[db].post(object, options || {});
         },
         remove: function(db, object, options) {
-          return databases[db].remove(object, options);
+          return databases[db].remove(object, options || {});
         },
         get: function(db, object, options) {
-          return databases[db].get(object, options);
+          return databases[db].get(object, options || {});
         },
         session: {},
         errors: {},


### PR DESCRIPTION
Throws an error on change while searching for keys on an undefined object. If options are undefined, we pass a empty object

```
Uncaught (in promise) TypeError: Cannot read property 'force' of undefined
```